### PR TITLE
Remove ip forward and external ip

### DIFF
--- a/docs/02-compute-resources.md
+++ b/docs/02-compute-resources.md
@@ -45,22 +45,6 @@ sigstore-the-hard-way-allow-external       sigstore-the-hard-way-proj  INGRESS  
 sigstore-the-hard-way-proj-allow-internal  sigstore-the-hard-way-proj  INGRESS    1000      tcp,udp,icmp                      False
 ```
 
-Create an external IP range
-
-```bash
-$ gcloud compute addresses create sigstore-the-hard-way-proj \
-    --region $(gcloud config get-value compute/region)
-```
-
-Verify the external IP range
-
-```bash
-$ gcloud compute addresses list --filter="name=('sigstore-the-hard-way-proj')"
-
-NAME                        ADDRESS/RANGE  TYPE      PURPOSE  NETWORK  REGION        SUBNET  STATUS
-sigstore-the-hard-way-proj  34.79.121.255  EXTERNAL                    europe-west1          RESERVED
-```
-
 ## Compute Resources
 
 Now we need to create four compute nodes for each service.

--- a/docs/02-compute-resources.md
+++ b/docs/02-compute-resources.md
@@ -69,7 +69,6 @@ Now we need to create four compute nodes for each service.
 $ gcloud compute instances create sigstore-rekor \
     --async \
     --boot-disk-size 200GB \
-    --can-ip-forward \
     --image-family debian-10 \
     --image-project debian-cloud \
     --machine-type e2-small \
@@ -83,7 +82,6 @@ $ gcloud compute instances create sigstore-rekor \
 $ gcloud compute instances create sigstore-fulcio \
     --async \
     --boot-disk-size 200GB \
-    --can-ip-forward \
     --image-family debian-10 \
     --image-project debian-cloud \
     --machine-type e2-small \
@@ -97,7 +95,6 @@ $ gcloud compute instances create sigstore-fulcio \
 $ gcloud compute instances create sigstore-oauth2 \
     --async \
     --boot-disk-size 200GB \
-    --can-ip-forward \
     --image-family debian-10 \
     --image-project debian-cloud \
     --machine-type e2-small \
@@ -111,7 +108,6 @@ $ gcloud compute instances create sigstore-oauth2 \
 $ gcloud compute instances create sigstore-ctl \
     --async \
     --boot-disk-size 200GB \
-    --can-ip-forward \
     --image-family debian-10 \
     --image-project debian-cloud \
     --machine-type e2-small \


### PR DESCRIPTION
These are two more hold overs from kubernetes-the-hard-way. The external IP address isn't used in here and we also don't need to have nodes that support IP forwarding (this was used for the CNI in kubernetes-the-hard-way)