### PR TITLE
03-domain-configuration: Use a variable to refer to the domain

### DIFF
--- a/src/03-domain-configuration.md
+++ b/src/03-domain-configuration.md
@@ -8,6 +8,14 @@ Now that are instances are running, lets grab the external IP's and set up domai
 
 ## Configuration
 
+Export a variable that will point to the domain you just bought. In this example we'll be using `example.com`:
+
+```bash
+export DOMAIN="example.com"
+```
+
+We'll be using this variable throughout the following code-snippets.
+
 ### rekor.example.com
 
 Grab your external / public IP
@@ -28,7 +36,7 @@ To create resource records on Google,
 If you're using GCP as the DNS provider this can be done as follows
 
 ```bash
-gcloud dns record-sets create rekor.example.com. \
+gcloud dns record-sets create rekor.$DOMAIN. \
   --rrdatas=$(gcloud compute instances describe sigstore-rekor --format='get(networkInterfaces[0].accessConfigs[0].natIP)') \
   --type=A --ttl=60 --zone=example-com
 ```
@@ -49,7 +57,7 @@ gcloud compute instances describe sigstore-fulcio \
 If you're using GCP as the DNS provider this can be done as follows
 
 ```bash
-gcloud dns record-sets create fulcio.example.com. \
+gcloud dns record-sets create fulcio.$DOMAIN. \
   --rrdatas=$(gcloud compute instances describe sigstore-fulcio --format='get(networkInterfaces[0].accessConfigs[0].natIP)') \
   --type=A --ttl=60 --zone=example-com
 ```
@@ -68,7 +76,7 @@ gcloud compute instances describe sigstore-oauth2 \
 If you're using GCP as the DNS provider this can be done as follows
 
 ```bash
-gcloud dns record-sets create oauth2.example.com. \
+gcloud dns record-sets create oauth2.$DOMAIN. \
   --rrdatas=$(gcloud compute instances describe sigstore-oauth2 --format='get(networkInterfaces[0].accessConfigs[0].natIP)') \
   --type=A --ttl=60 --zone=example-com
 ```


### PR DESCRIPTION
#### Summary

The examples use a hard-coded zone and domain. The zone is quite
flexible and folks can very easily use `example-com` as the examples do.
However, having to replace the domain in each command can be a little
tedious. To make things easier for the reader, this sets a variable with
the domain in the beginning of the section and uses it throughout the
code snippets. This way, it's easier for folks to use the command line
snippets directly with less mistakes.

#### Release Note
```release-note
NONE
```
