### PR TITLE
Pin to a specific golang 1.17 release

### DIFF
--- a/src/04-rekor.md
+++ b/src/04-rekor.md
@@ -49,14 +49,14 @@ chmod +x installer_linux
 ```
 
 ```bash
-./installer_linux
+./installer_linux -version 1.17.13
 ```
 
 e.g.
 
 ```
 Welcome to the Go installer!
-Downloading Go version go1.17.1 to /home/luke/.go
+Downloading Go version go1.17.13 to /home/luke/.go
 This may take a bit of time...
 Downloaded!
 Setting up GOPATH
@@ -72,6 +72,11 @@ As suggested run
 ```bash
 source /home/$USER/.bash_profile
 go version
+```
+
+The output should be as follows
+
+```bash
 go version go1.17.1 linux/amd64
 ```
 

--- a/src/05-dex.md
+++ b/src/05-dex.md
@@ -43,14 +43,14 @@ chmod +x installer_linux
 ```
 
 ```bash
-./installer_linux
+./installer_linux -version 1.17.13
 ```
 
 e.g.
 
 ```
 Welcome to the Go installer!
-Downloading Go version go1.17.1 to /home/luke/.go
+Downloading Go version go1.17.13 to /home/luke/.go
 This may take a bit of time...
 Downloaded!
 Setting up GOPATH
@@ -66,6 +66,11 @@ As suggested run
 ```bash
 source /home/$USER/.bash_profile
 go version
+```
+
+The output should be as follows:
+
+```bash
 go version go1.17.1 linux/amd64
 ```
 

--- a/src/06-fulcio.md
+++ b/src/06-fulcio.md
@@ -51,14 +51,14 @@ chmod +x installer_linux
 ```
 
 ```bash
-./installer_linux
+./installer_linux -version 1.17.13
 ```
 
 e.g.
 
 ```
 Welcome to the Go installer!
-Downloading Go version go1.17.1 to /home/luke/.go
+Downloading Go version go1.17.13 to /home/luke/.go
 This may take a bit of time...
 Downloaded!
 Setting up GOPATH
@@ -74,6 +74,11 @@ As suggested run
 ```bash
 source /home/$USER/.bash_profile
 go version
+````
+
+The output should be as follows:
+
+```bash
 go version go1.17.1 linux/amd64
 ```
 

--- a/src/07-certifcate-transparency.md
+++ b/src/07-certifcate-transparency.md
@@ -39,14 +39,14 @@ chmod +x installer_linux
 ```
 
 ```bash
-./installer_linux
+./installer_linux -version 1.17.13
 ```
 
 e.g.
 
 ```
 Welcome to the Go installer!
-Downloading Go version go1.17.1 to /home/luke/.go
+Downloading Go version go1.17.13 to /home/luke/.go
 This may take a bit of time...
 Downloaded!
 Setting up GOPATH
@@ -62,6 +62,11 @@ As suggested run
 ```bash
 source /home/$USER/.bash_profile
 go version
+```
+
+The output should be as follows:
+
+```bash
 go version go1.17.1 linux/amd64
 ```
 


### PR DESCRIPTION
#### Summary

Rekor seems to have having issues with 1.18 and 1.19, by pinning to a
specific release we ensure that readers will get a reproduceable
environment without these bugs.

#### Release Note
```release-note
NONE
```
