### PR TITLE
Fix dex config path

### DIFF
--- a/src/05-dex.md
+++ b/src/05-dex.md
@@ -358,7 +358,7 @@ sudo mv dex-config.yaml /etc/dex/
 ### Start dex
 
 ```bash
-dex serve --web-http-addr=0.0.0.0:6000  dex-config.yaml
+dex serve --web-http-addr=0.0.0.0:6000  /etc/dex/dex-config.yaml
 ```
 
 You may create a bare minimal systemd service for dex


### PR DESCRIPTION
#### Summary
The path that was being used to serve the configuration when invoking
dex manually was not right. This now sets the absolute path.

#### Ticket Link

Fixes #19

#### Release Note
```release-note
NONE
```
