### PR TITLE
migrate badge and gh-pages url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # sigstore the hardway
 
-![Publish Status](https://github.com/lukehinds/sigstore-the-hard-way/workflows/publish/badge.svg)
+![Publish Status](https://github.com/stacklok/sigstore-the-hard-way/workflows/publish/badge.svg)
 
-sigstore the hard way is hosted at <https://sthw.decodebytes.sh> and is available for free.
+sigstore the hard way is hosted at <https://stacklok.github.io/sigstore-the-hard-way/> and is available for free.
 
-If the above URL does not work, you can also see the site [here](https://lukehinds.github.io/sigstore-the-hard-way/)
 
 ## contributing
 


### PR DESCRIPTION
GitHub redirects the repo URL, but the published site 404s: https://lukehinds.github.io/sigstore-the-hard-way/

I assumed https://sthw.decodebytes.sh/ was also personal hosting, so the Stacklok owned GitHub pages site should be the only URL.