### PR TITLE
Replace deprecated getgo command with updated instructions

### DIFF
--- a/src/04-rekor.md
+++ b/src/04-rekor.md
@@ -38,43 +38,7 @@ sudo apt-get install mariadb-server git redis-server haproxy certbot -y
 
 ### Install latest golang compiler
 
-Download and run the golang installer (system package are often older than what rekor requires):
-
-```bash
-curl -O https://storage.googleapis.com/golang/getgo/installer_linux
-```
-
-```bash
-chmod +x installer_linux
-```
-
-```bash
-./installer_linux
-```
-
-e.g.
-
-```bash
-Welcome to the Go installer!
-Downloading Go version go1.20.4 to /home/luke/.go
-This may take a bit of time...
-Downloaded!
-Setting up GOPATH
-GOPATH has been set up!
-
-One more thing! Run `source /home/$USER/.bash_profile` to persist the
-new environment variables to your current session, or open a
-new shell prompt.
-```
-
-As suggested run:
-
-```bash
-source /home/$USER/.bash_profile
-
-go version
-go version go1.20.4 linux/amd64
-```
+Follow the [Download and install](https://go.dev/doc/install) steps to install Go (system package are often older than what rekor requires)
 
 ### Install rekor
 

--- a/src/05-dex.md
+++ b/src/05-dex.md
@@ -32,43 +32,8 @@ sudo apt-get install haproxy make git gcc certbot -y
 
 ### Install latest golang compiler
 
-Download and run the golang installer (system package are often older than what Dex requires):
+Follow the [Download and install](https://go.dev/doc/install) steps to install Go (system package are often older than what Dex requires)
 
-```bash
-curl -O https://storage.googleapis.com/golang/getgo/installer_linux
-```
-
-```bash
-chmod +x installer_linux
-```
-
-```bash
-./installer_linux
-```
-
-e.g.
-
-```
-Welcome to the Go installer!
-Downloading Go version go1.20.4 to /home/luke/.go
-This may take a bit of time...
-Downloaded!
-Setting up GOPATH
-GOPATH has been set up!
-
-One more thing! Run `source /home/$USER/.bash_profile` to persist the
-new environment variables to your current session, or open a
-new shell prompt.
-```
-
-As suggested run
-
-```bash
-source /home/$USER/.bash_profile
-
-go version
-go version go1.20.4 linux/amd64
-```
 
 ### Let's encrypt (TLS) & HA Proxy config
 

--- a/src/06-fulcio.md
+++ b/src/06-fulcio.md
@@ -40,42 +40,8 @@ sudo apt-get install git gcc haproxy softhsm certbot opensc -y
 
 ### Install latest golang compiler
 
-Download and run the golang installer (system package are often older than what Fulcio requires):
+Follow the [Download and install](https://go.dev/doc/install) steps to install Go (system package are often older than what Fulcio requires)
 
-```bash
-curl -O https://storage.googleapis.com/golang/getgo/installer_linux
-```
-
-```bash
-chmod +x installer_linux
-```
-
-```bash
-./installer_linux
-```
-
-e.g.
-
-```
-Welcome to the Go installer!
-Downloading Go version go1.20.4 to /home/luke/.go
-This may take a bit of time...
-Downloaded!
-Setting up GOPATH
-GOPATH has been set up!
-
-One more thing! Run `source /home/$USER/.bash_profile` to persist the
-new environment variables to your current session, or open a
-new shell prompt.
-```
-
-As suggested run
-
-```bash
-source /home/$USER/.bash_profile
-go version
-go version go1.20.4 linux/amd64
-```
 
 ### Install Fulcio
 

--- a/src/07-certifcate-transparency.md
+++ b/src/07-certifcate-transparency.md
@@ -28,42 +28,8 @@ sudo apt-get install mariadb-server git wget -y
 
 ### Install latest golang compiler
 
-Download and run the golang installer (system package are often older than what Trillian requires):
+Follow the [Download and install](https://go.dev/doc/install) steps to install Go (system package are often older than what Trillian requires)
 
-```bash
-curl -O https://storage.googleapis.com/golang/getgo/installer_linux
-```
-
-```bash
-chmod +x installer_linux
-```
-
-```bash
-./installer_linux
-```
-
-e.g.
-
-```bash
-Welcome to the Go installer!
-Downloading Go version go1.20.4 to /home/luke/.go
-This may take a bit of time...
-Downloaded!
-Setting up GOPATH
-GOPATH has been set up!
-
-One more thing! Run `source /home/$USER/.bash_profile` to persist the
-new environment variables to your current session, or open a
-new shell prompt.
-```
-
-As suggested run
-
-```bash
-source /home/$USER/.bash_profile
-go version
-go version go1.20.4 linux/amd64
-```
 
 ### Database
 


### PR DESCRIPTION
**Description:**
This pull request replaces the deprecated getgo command with a direct link to the updated installation instructions on the Go website.

**Changes Made:**
Updated documentation to redirect users to the current installation process for the latest golang compiler.

**Additional Notes:**
This PR is in line with the discussion on issue [#62112](https://github.com/golang/go/issues/62112) regarding the deprecation of the getgo command.

